### PR TITLE
修复文章链接跳转404的问题

### DIFF
--- a/docs/front-end-work/interview/interview-2-stage.md
+++ b/docs/front-end-work/interview/interview-2-stage.md
@@ -73,4 +73,5 @@ HR更多是在考察面试者的稳定性，常见的问题包括“为什么跳
 
 ## 结束语
 一次面试过程算下来可能多的有七八轮，少的也有四五轮，找工作真是场持久战呢。一份合适的工作真的不容易，我们常常在这个过程慢慢地失去最初对这个行业的憧憬，但请不要放弃，要相信困难的日子会慢慢过去的。
-如果你想了解这些年前端的一些感想和经验，也可看[《前端这些年》](../front-end-days/about-front-end-1-begin-in)系列。
+如果你想了解这些年前端的一些感想和经验，也可看[《前端这几年》](../front-end-days/about-front-end-1-begin-in)
+http://www.godbasin.com/front-end-work/front-end-days/about-front-end-1-begin-in.html系列。


### PR DESCRIPTION
[《前端这些年》](../front-end-days/about-front-end-1-begin-in)
改成：
[《前端这几年》](../front-end-days/about-front-end-1-begin-in)
http://www.godbasin.com/front-end-work/front-end-days/about-front-end-1-begin-in.html

顺便问一句，为啥跳转后的路径是对的完整的，但实际显示却是404呢，页面要再刷新一下才能访问。